### PR TITLE
feat(css): 添加canvas元素的指针事件支持

### DIFF
--- a/js_node/weilin_fix.css
+++ b/js_node/weilin_fix.css
@@ -73,6 +73,7 @@
 .dom-widget.size-full textarea,
 .dom-widget.size-full input,
 .dom-widget.size-full select,
-.dom-widget.size-full button {
+.dom-widget.size-full button,
+.dom-widget.size-full canvas {
     pointer-events: auto !important;
 }


### PR DESCRIPTION
CSS 选择器 .dom-widget.size-full 误伤了使用 canvas 的第三方插件，导致其他插件某些节点无法正常使用，包括但不限于：
ComfyUI-Easy-Sam3
ComfyUI-KJNodes